### PR TITLE
Eid 1422 allow proxy config to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Splunk Logging for Java
 
-#### Version 1.7.3
+This is a fork of [Splunk's java logging library](https://github.com/splunk/splunk-library-javalogging). It was originally
+forked so we could enhance it to allow the configuration of the Apache http client used by the library, specifically the 
+http proxy settings. The aim is to get this change merged upstream.
+
+#### Version 1.1.0
 
 Splunk logging for Java enables you to log events to HTTP Event Collector or to a TCP input on a Splunk Enterprise instance within your Java applications. You can use three major Java logging frameworks: [Logback](http://logback.qos.ch), [Log4j 2](http://logging.apache.org/log4j/2.x/), and [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html). Splunk logging for Java is also enabled for [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org).
 
@@ -15,6 +19,12 @@ Splunk logging for Java provides:
 * Example configuration files for all three frameworks that show how to configure the frameworks to write to HTTP Event Collector or TCP ports.
 
 * Support for batching events (sent to HTTP Event Collector only).</li>
+
+### Packaging and publishing
+
+The library is [built, packaged and published by Concourse](https://deployer.tools.signin.service.gov.uk/teams/main/pipelines/build-libraries/jobs/build-splunk-library-javalogging). It's published to both of alphagov's 
+bintray and artifactory. When making changes you need to manually bump the version in the pom.xml. Creds for bintray and 
+artifactory are pulled from the Concourse environement.
 
 ### Requirements
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.splunk.logging</groupId>
+    <groupId>uk.gov.ida</groupId>
     <artifactId>splunk-library-javalogging</artifactId>
-    <version>1.7.3</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>Splunk Logging for Java</name>
     <url>http://dev.splunk.com/goto/sdk-slj</url>
 
-    <description>Library for structured, semantic logging of Common Information Model compliant events, meant for use
-        with SLF4J.
+    <description>Verify's fork of Splunk's java logging library
     </description>
 
     <properties>
@@ -71,20 +70,26 @@
                             </excludes>
                         </configuration>
                     </plugin>
-
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <groupId>org.jfrog.buildinfo</groupId>
+                        <artifactId>artifactory-maven-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <inherited>false</inherited>
                         <executions>
                             <execution>
-                                <id>attach-javadocs</id>
-                                <configuration>
-                                    <additionalparam>-Xdoclint:syntax</additionalparam>
-                                    <additionalOptions>-Xdoclint:syntax</additionalOptions>
-                                </configuration>
+                                <id>artifactory</id>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>publish</goal>
                                 </goals>
+                                <configuration>
+                                    <publisher>
+                                        <contextUrl>https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory</contextUrl>
+                                        <username>${env.ARTIUSER}</username>
+                                        <password>${env.ARTIPASSWORD}</password>
+                                        <repoKey>libs-release-local</repoKey>
+                                        <snapshotRepoKey>libs-snapshot-local</snapshotRepoKey>
+                                    </publisher>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -253,36 +258,12 @@
         </license>
     </licenses>
 
-    <organization>
-        <name>Splunk, Inc.</name>
-        <url>http://dev.splunk.com</url>
-    </organization>
-
-    <contributors>
-        <contributor>
-            <name>Paul van Assen</name>
-            <email>source@pvanassen.nl</email>
-        </contributor>
-        <contributor>
-            <name>Damien Dallimore</name>
-            <email>ddallimore@splunk.com</email>
-        </contributor>
-        <contributor>
-            <name>Fred Ross</name>
-            <email>fross@splunk.com</email>
-        </contributor>
-        <contributor>
-            <name>Shakeel Mohamed</name>
-            <email>shakeel@splunk.com</email>
-        </contributor>
-    </contributors>
-
-    <scm>
-        <connection>scm:git:git@github.com:splunk/splunk-library-javalogging.git</connection>
-        <developerConnection>scm:git:git@github.com:splunk/splunk-library-javalogging.git</developerConnection>
-        <tag>HEAD</tag>
-        <url>https://github.com/splunk/splunk-library-javalogging</url>
-    </scm>
-
+    <distributionManagement>
+        <repository>
+            <id>bintray-alphagov</id>
+            <name>alphagov-maven-test</name>
+            <url>https://api.bintray.com/maven/alphagov/maven-test/splunk-library-javalogging/;publish=1</url>
+        </repository>
+    </distributionManagement>
 
 </project>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+    <server>
+        <id>bintray-alphagov</id>
+        <username>${env.BINTRAY_USER}</username>
+        <password>${env.BINTRAY_API_KEY}</password>
+    </server>
+    </servers>
+</settings>

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -19,8 +19,8 @@ import ch.qos.logback.classic.pattern.MarkerConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.Layout;
+import org.apache.http.HttpHost;
 
-import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -52,6 +52,8 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
     private long _batchSize = 0;
     private String _sendMode;
     private long _retriesOnError = 0;
+    private String _httpProxyHost;
+    private int _httpProxyPort;
 
     @Override
     public void start() {
@@ -75,8 +77,14 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
         if (_messageFormat != null)
             metadata.put(HttpEventCollectorSender.MetadataMessageFormatTag, _messageFormat);
 
+        // create proxy host if required
+        HttpHost proxyHost = null;
+        if (_httpProxyHost != null && !_httpProxyHost.isEmpty() && _httpProxyPort != 0) {
+            proxyHost = new HttpHost(_httpProxyHost, _httpProxyPort);
+        }
+
         this.sender = new HttpEventCollectorSender(
-                _url, _token, _channel, _type, _batchInterval, _batchCount, _batchSize, _sendMode, metadata);
+                _url, _token, _channel, _type, _batchInterval, _batchCount, _batchSize, _sendMode, metadata, proxyHost);
 
         // plug a user middleware
         if (_middleware != null && !_middleware.isEmpty()) {
@@ -303,6 +311,10 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
     public void setEventBodySerializer(String eventBodySerializer) {
         this._eventBodySerializer = eventBodySerializer;
     }
+
+    public void setHttpProxyHost(String httpProxyHost) { this._httpProxyHost = httpProxyHost; }
+
+    public void setHttpProxyPort(int httpProxyPort) { this._httpProxyPort = httpProxyPort; }
 
     private static long parseLong(String string, int defaultValue) {
         try {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -18,6 +18,7 @@ package com.splunk.logging;
  * under the License.
  */
 
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
@@ -28,6 +29,7 @@ import org.apache.http.conn.ssl.SSLContexts;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.util.EntityUtils;
 
@@ -100,6 +102,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     private HttpEventCollectorMiddleware middleware = new HttpEventCollectorMiddleware();
     private final MessageFormat messageFormat;
     private EventBodySerializer eventBodySerializer;
+    private HttpHost proxyHost;
 
     /**
      * Initialize HttpEventCollectorSender
@@ -111,16 +114,24 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
      * @param metadata events metadata
      * @param channel unique GUID for the client to send raw events to the server
      * @param type event data type
+     * @param proxyHost HttpHost to use as a proxy
      */
     public HttpEventCollectorSender(
-            final String Url, final String token, final String channel, final String type,
-            long delay, long maxEventsBatchCount, long maxEventsBatchSize,
+            final String Url,
+            final String token,
+            final String channel,
+            final String type,
+            long delay,
+            long maxEventsBatchCount,
+            long maxEventsBatchSize,
             String sendModeStr,
-            Dictionary<String, String> metadata) {
+            Dictionary<String, String> metadata,
+            HttpHost proxyHost) {
         this.url = Url + HttpEventCollectorUriPath;
         this.token = token;
         this.channel = channel;
         this.type = type;
+        this.proxyHost = proxyHost;
 
         if ("Raw".equalsIgnoreCase(type)) {
             this.url = Url + HttpRawCollectorUriPath;
@@ -288,12 +299,18 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
         // limit max  number of async requests in sequential mode, 0 means "use
         // default limit"
         int maxConnTotal = sendMode == SendMode.Sequential ? 1 : 0;
+
+        HttpAsyncClientBuilder httpAsyncClientBuilder = HttpAsyncClients
+            .custom()
+            .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+            .setMaxConnTotal(maxConnTotal);
+        if(proxyHost != null) {
+            // set the proxy if required
+            httpAsyncClientBuilder.setProxy(proxyHost);
+        }
         if (! disableCertificateValidation) {
             // create an http client that validates certificates
-            httpClient = HttpAsyncClients.custom()
-                    .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
-                    .setMaxConnTotal(maxConnTotal)
-                    .build();
+            httpClient = httpAsyncClientBuilder.build();
         } else {
             // create strategy that accepts all certificates
             TrustStrategy acceptingTrustStrategy = new TrustStrategy() {
@@ -306,9 +323,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
             try {
                 sslContext = SSLContexts.custom().loadTrustMaterial(
                         null, acceptingTrustStrategy).build();
-                httpClient = HttpAsyncClients.custom()
-                        .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
-                        .setMaxConnTotal(maxConnTotal)
+                httpClient = httpAsyncClientBuilder
                         .setHostnameVerifier(SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER)
                         .setSSLContext(sslContext)
                         .build();

--- a/src/test/java/HttpEventCollectorUnitTest.java
+++ b/src/test/java/HttpEventCollectorUnitTest.java
@@ -17,21 +17,20 @@
  */
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
 
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
-import sun.rmi.runtime.Log;
 
 import java.io.ByteArrayInputStream;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 public class HttpEventCollectorUnitTest {
     @Test
@@ -44,6 +43,8 @@ public class HttpEventCollectorUnitTest {
         userInputs.put("user_batch_size_count", "1");
         userInputs.put("user_batch_size_bytes", "0");
         userInputs.put("user_eventBodySerializer", "DoesNotExistButShouldNotCrashTest");
+        userInputs.put("user_httpProxyHost", "example.com");
+        userInputs.put("user_httpProxyPort", "5000");
         TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
         org.apache.logging.log4j.Logger LOG4J = org.apache.logging.log4j.LogManager.getLogger(loggerName);
 
@@ -73,6 +74,8 @@ public class HttpEventCollectorUnitTest {
         userInputs.put("user_httpEventCollector_token", "11111111-2222-3333-4444-555555555555");
         userInputs.put("user_middleware", "HttpEventCollectorUnitTestMiddleware");
         userInputs.put("user_eventBodySerializer", "DoesNotExistButShouldNotCrashTest");
+        userInputs.put("user_httpProxyHost", "example.com");
+        userInputs.put("user_httpProxyPort", "5000");
         TestUtil.resetLogbackConfiguration("logback_template.xml", "logback.xml", userInputs);
         org.slf4j.Logger LOGBACK = org.slf4j.LoggerFactory.getLogger(loggerName);
 
@@ -104,7 +107,9 @@ public class HttpEventCollectorUnitTest {
             "com.splunk.logging.HttpEventCollectorLoggingHandler.batch_size_bytes=0\n" +
             "com.splunk.logging.HttpEventCollectorLoggingHandler.batch_interval=0\n" +
             "com.splunk.logging.HttpEventCollectorLoggingHandler.middleware=HttpEventCollectorUnitTestMiddleware\n" +
-            "com.splunk.logging.HttpEventCollectorLoggingHandler.eventBodySerializer=DoesNotExistButShouldNotCrashTest\n"
+            "com.splunk.logging.HttpEventCollectorLoggingHandler.eventBodySerializer=DoesNotExistButShouldNotCrashTest\n" +
+            "com.splunk.logging.HttpEventCollectorLoggingHandler.httpProxyHost=example.com\n" +
+            "com.splunk.logging.HttpEventCollectorLoggingHandler.httpProxyPort=5000\n"
         );
 
         // send 3 events

--- a/src/test/resources/log4j2_template.xml
+++ b/src/test/resources/log4j2_template.xml
@@ -17,6 +17,8 @@
               send_mode="%user_send_mode%"
               middleware="%user_middleware%"
               eventBodySerializer="%user_eventBodySerializer%"
+              httpProxyHost="%user_httpProxyHost%"
+              httpProxyPort="%user_httpProxyPort%"
                 >
 
             <PatternLayout pattern="%m"/>

--- a/src/test/resources/logback_template.xml
+++ b/src/test/resources/logback_template.xml
@@ -18,6 +18,8 @@
         <send_mode>%user_send_mode%</send_mode>
         <middleware>%user_middleware%</middleware>
         <eventBodySerializer>%user_eventBodySerializer%</eventBodySerializer>
+        <httpProxyHost>%user_httpProxyHost%</httpProxyHost>
+        <httpProxyPort>%user_httpProxyPort%</httpProxyPort>
 
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%msg</pattern>


### PR DESCRIPTION
### EID-1422 Allow an HTTP proxy to be configured
`HttpEventCollectorSender` uses an Apache `CloseableHttpAsyncClient` for
making http requests. This commit allows configuration for an http proxy
to be passed to the client via the appenders/handler.

### EID-1422 Add publishing config to pom.xml  …
This updates the pom.xml to publish the packaged artifact to bintray and
artifactory.

The settings.xml is included here for the Concourse build pipeline which
will move it to the home directory, where Maven will find it. Creds are
pulled from the Concourse environment.

