### PR TITLE
Mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Splunk Logging for Java
 
+> **Verify has Closed**
+>
+>This repository is out of date and has been archived
+
 This is a fork of [Splunk's java logging library](https://github.com/splunk/splunk-library-javalogging). It was originally
 forked so we could enhance it to allow the configuration of the Apache http client used by the library, specifically the 
 http proxy settings. The aim is to get this change merged upstream.


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.